### PR TITLE
User routes

### DIFF
--- a/chat_backend/src/main.rs
+++ b/chat_backend/src/main.rs
@@ -8,6 +8,7 @@ use env_logger::Env;
 
 mod entities;
 mod routes;
+mod utils;
 mod handlers;
 mod models;
 mod seed;

--- a/chat_backend/src/models/user_models.rs
+++ b/chat_backend/src/models/user_models.rs
@@ -70,6 +70,7 @@ pub struct UpdateUser {
     pub username: Option<String>,
     pub role_id: Option<i32>,
     pub avatar: Option<String>,
+    pub password: Option<String>,
 }
 
 #[derive(Deserialize)]

--- a/chat_backend/src/models/user_models.rs
+++ b/chat_backend/src/models/user_models.rs
@@ -54,6 +54,16 @@ pub struct UserFilter {
 }
 
 #[derive(Deserialize)]
+pub struct CreateUser {
+    pub first_name: String,
+    pub last_name: String,
+    pub username: String,
+    pub password: String,
+    pub role_id: Option<i32>,
+    pub avatar: Option<String>,
+}
+
+#[derive(Deserialize)]
 pub struct UpdateUser {
     pub first_name: Option<String>,
     pub last_name: Option<String>,

--- a/chat_backend/src/routes/user_routes.rs
+++ b/chat_backend/src/routes/user_routes.rs
@@ -8,20 +8,21 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
             // Public endpoints (no middleware applied)
             .route("/register", web::post().to(user_handler::register))
             .route("/login", web::post().to(user_handler::login))
-            // Admin-only endpoints: get all users, update and delete a user.
-            .service(
-                web::scope("")
-                    .wrap(RoleGuard::new(vec!["admin"]))
-                    .route("/all", web::get().to(user_handler::get_users))
-                    .route("/{id}", web::put().to(user_handler::update_user))
-                    .route("/create", web::post().to(user_handler::create_user))
-                    .route("/{id}", web::delete().to(user_handler::delete_user))
-            )
             // Protected endpoint: get a single user, accessible by both admin and user.
             .service(
                 web::scope("")
                     .wrap(RoleGuard::new(vec!["admin", "user"]))
                     .route("/{id}", web::get().to(user_handler::get_user))
+                    .route("/{id}", web::put().to(user_handler::update_user))
             )
+            // Admin-only endpoints: get all users, update and delete a user.
+            .service(
+                web::scope("")
+                    .wrap(RoleGuard::new(vec!["admin"]))
+                    .route("/all", web::get().to(user_handler::get_users))
+                    .route("/create", web::post().to(user_handler::create_user))
+                    .route("/{id}", web::delete().to(user_handler::delete_user))
+            )
+            
     );
 }

--- a/chat_backend/src/routes/user_routes.rs
+++ b/chat_backend/src/routes/user_routes.rs
@@ -14,6 +14,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
                     .wrap(RoleGuard::new(vec!["admin"]))
                     .route("/all", web::get().to(user_handler::get_users))
                     .route("/{id}", web::put().to(user_handler::update_user))
+                    .route("/create", web::post().to(user_handler::create_user))
                     .route("/{id}", web::delete().to(user_handler::delete_user))
             )
             // Protected endpoint: get a single user, accessible by both admin and user.

--- a/chat_backend/src/routes/user_routes.rs
+++ b/chat_backend/src/routes/user_routes.rs
@@ -5,24 +5,34 @@ use crate::middleware::claims::RoleGuard;
 pub fn configure(cfg: &mut web::ServiceConfig) {
     cfg.service(
         web::scope("/users")
-            // Public endpoints (no middleware applied)
+            // Public endpoints – no guard attached.
             .route("/register", web::post().to(user_handler::register))
             .route("/login", web::post().to(user_handler::login))
-            // Protected endpoint: get a single user, accessible by both admin and user.
+            
+            // Admin-only endpoints with their own resources
             .service(
-                web::scope("")
-                    .wrap(RoleGuard::new(vec!["admin", "user"]))
-                    .route("/{id}", web::get().to(user_handler::get_user))
-                    .route("/{id}", web::put().to(user_handler::update_user))
-            )
-            // Admin-only endpoints: get all users, update and delete a user.
-            .service(
-                web::scope("")
+                web::resource("/all")
                     .wrap(RoleGuard::new(vec!["admin"]))
-                    .route("/all", web::get().to(user_handler::get_users))
-                    .route("/create", web::post().to(user_handler::create_user))
-                    .route("/{id}", web::delete().to(user_handler::delete_user))
+                    .route(web::get().to(user_handler::get_users))
+            )
+            .service(
+                web::resource("/create")
+                    .wrap(RoleGuard::new(vec!["admin"]))
+                    .route(web::post().to(user_handler::create_user))
             )
             
+            // Single resource for user ID operations with different role guards
+            .service(
+                web::resource("/{id:\\d+}")
+                    .route(web::get()
+                        .guard(RoleGuard::new(vec!["admin", "user"]))
+                        .to(user_handler::get_user))
+                    .route(web::put()
+                        .guard(RoleGuard::new(vec!["admin", "user"]))
+                        .to(user_handler::update_user))
+                    .route(web::delete()
+                        .guard(RoleGuard::new(vec!["admin"]))
+                        .to(user_handler::delete_user))
+            )
     );
 }

--- a/chat_backend/src/utils/check_auth_user.rs
+++ b/chat_backend/src/utils/check_auth_user.rs
@@ -1,0 +1,36 @@
+use actix_web::{Error, FromRequest, HttpRequest};
+use futures::future::{ready, Ready};
+use jsonwebtoken::{decode, DecodingKey, Validation};
+use crate::models::token_model::Claims;
+
+pub struct AuthenticatedUser(pub Claims);
+
+impl AuthenticatedUser {
+    /// Extracts the token claims from the request headers.
+    pub fn from_headers(req: &HttpRequest) -> Result<Self, Error> {
+        if let Some(auth_header) = req.headers().get("Authorization") {
+            if let Ok(auth_str) = auth_header.to_str() {
+                if auth_str.starts_with("Bearer ") {
+                    let token = auth_str.trim_start_matches("Bearer ").trim();
+                    let secret = std::env::var("JWT_SECRET")
+                        .map_err(|_| actix_web::error::ErrorUnauthorized("JWT secret missing"))?;
+                    let decoding_key = DecodingKey::from_secret(secret.as_bytes());
+                    let token_data = decode::<Claims>(token, &decoding_key, &Validation::default())
+                        .map_err(|_| actix_web::error::ErrorUnauthorized("Invalid token"))?;
+                    return Ok(AuthenticatedUser(token_data.claims));
+                }
+            }
+        }
+        Err(actix_web::error::ErrorUnauthorized("Unauthorized"))
+    }
+}
+
+
+impl FromRequest for AuthenticatedUser {
+    type Error = Error;
+    type Future = Ready<Result<Self, Self::Error>>;
+
+    fn from_request(req: &HttpRequest, _payload: &mut actix_web::dev::Payload) -> Self::Future {
+        ready(AuthenticatedUser::from_headers(req))
+    }
+}

--- a/chat_backend/src/utils/check_auth_user.rs
+++ b/chat_backend/src/utils/check_auth_user.rs
@@ -1,4 +1,4 @@
-use actix_web::{Error, FromRequest, HttpRequest};
+use actix_web::{http::header::HeaderMap, Error, FromRequest, HttpRequest};
 use futures::future::{ready, Ready};
 use jsonwebtoken::{decode, DecodingKey, Validation};
 use crate::models::token_model::Claims;
@@ -8,7 +8,12 @@ pub struct AuthenticatedUser(pub Claims);
 impl AuthenticatedUser {
     /// Extracts the token claims from the request headers.
     pub fn from_headers(req: &HttpRequest) -> Result<Self, Error> {
-        if let Some(auth_header) = req.headers().get("Authorization") {
+        Self::from_headers_ref(req.headers())
+    }
+    
+    /// Extracts the token claims from a header reference.
+    pub fn from_headers_ref(headers: &HeaderMap) -> Result<Self, Error> {
+        if let Some(auth_header) = headers.get("Authorization") {
             if let Ok(auth_str) = auth_header.to_str() {
                 if auth_str.starts_with("Bearer ") {
                     let token = auth_str.trim_start_matches("Bearer ").trim();

--- a/chat_backend/src/utils/mod.rs
+++ b/chat_backend/src/utils/mod.rs
@@ -1,0 +1,1 @@
+pub mod check_auth_user;


### PR DESCRIPTION
- Added Create User route for admins
- Changed the edit route to distinct between an admin and a user, making it so the user can edit their own profile if they are not admins 
- Changed it so the user can change his own password and can not do it for anybody else.
- Changed the RBAC middleware now works as a guard aswell as a Transform
- Fixed 2 bugs that kept our routes giving us either 404 Not Found or Method Not allowed because of overlap
- Closed Make all user routes issue